### PR TITLE
fix: исправление логики расчета объема в getUsedVolume (по объему "ящика")

### DIFF
--- a/goals.go
+++ b/goals.go
@@ -80,12 +80,15 @@ func countUsedBoxes(boxes []*Box) int {
 	return n
 }
 
-// getUsedVolume calculates the total volume of all boxes that contain items.
+// getUsedVolume calculates the total capacity of all boxes that contain items.
 func getUsedVolume(boxes []*Box) float64 {
 	var v float64
 
 	for _, b := range boxes {
-		v += b.itemsVolume
+		// Only count boxes that actually have items in them
+		if len(b.items) > 0 {
+			v += b.volume // Use the box's volume (capacity), not itemsVolume
+		}
 	}
 
 	return v


### PR DESCRIPTION
В этом исправлении изменена логика подсчета "использованного объема" в функции getUsedVolume, которая применяется в MinimizeBoxesGoal и TightestPackingGoal.

**Суть проблемы:**
Использовалось значение b.itemsVolume (суммарный объем предметов внутри). Это делало сравнение стратегий бессмысленным в ситуациях, когда разные алгоритмы упаковывали один и тот же набор предметов. В таких случаях itemsVolume у обоих вариантов одинаков, и функция сравнения не могла определить, какая упаковка "плотнее".

**Решение:**
Нужно сравнивать объем тары (b.volume / b.GetVolume()), а не объем содержимого.
Если два алгоритма упаковали одни и те же вещи, лучшим считается тот результат, который использовал ящики меньшего размера (меньше пустого места).